### PR TITLE
Aggiornamento struttura repository in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ La struttura della repository si presenta nel seguente modo:
 ```plaintext
 |-- .github
 |    |-- workflows
-|    |      |-- ingsw2122.yml
+|    |      |-- docker_build&push.yml
+|    |      |-- gradle_build.yml
 |-- build
 |    |-- reports
 |    |      |-- checkstyle
@@ -15,10 +16,12 @@ La struttura della repository si presenta nel seguente modo:
 |    |      |-- tests/test
 |–– config
 |    |–– checkstyle
+|    |–– pmd
 |–– docs
+|    |–– img
 |    |–– Assegnazione progetto.md
 |    |–– Guida per lo studente.md
-|    |–– img
+|    |–– ISPIRATORE.md
 |    |–– Report.md
 |–– drawings
 |–– gradle

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ La struttura della repository si presenta nel seguente modo:
 |–– docs
 |    |–– img
 |    |–– Assegnazione progetto.md
+|    |–– CODE_OF_CONDUCT.md
 |    |–– Guida per lo studente.md
 |    |–– ISPIRATORE.md
 |    |–– Report.md
@@ -42,20 +43,23 @@ La struttura della repository si presenta nel seguente modo:
 
 Nel seguito si dettagliano i ruoli dei diversi componenti:
 
-- `.github/workflows/`: contiene i file che dettagliano le direttive per assicurare la *continuous integration* attraverso l’uso di GitHub Actions;
-- `build/`: ospita la sottocartella `reports/`, contenente gli output dei tool automatici di test e controllo di qualità;
-- `config/`: ospita i file di configurazione. Le configurazioni di base richieste sono quelle per i tool checkstyle e PMD;
+- `.github/workflows/`: contiene i file che dettagliano le direttive per assicurare la *continuous integration* attraverso l’uso di GitHub Actions.
+- `build/`: ospita la sottocartella `reports/`, contenente gli output dei tool automatici di test e controllo di qualità.
+- `config/`: ospita i file di configurazione. Le configurazioni di base richieste sono quelle per i tool checkstyle e PMD.
 - `docs/`: ospita la documentazione di progetto, incluse le figure (nella sottocartella `img/`).
   Il file `Report.md` verrà usato per redigere la relazione finale del progetto.
   La cartella raccoglie inoltre:
   - `Assegnazione progetto.md`: contenente la descrizione dettagliata del progetto assegnato;
+  - `CODE_OF_CONDUCT.md`: dettaglia il codice di comportamento del gruppo;
   - `Guida per lo studente.md`: contenente la descrizione di tutti i passi di configurazione necessari per l'attivazione del flusso di lavoro a supporto dello sviluppo del progetto;
+  - `ISPIRATORE.md`: riporta biografia e principali contributi del personaggio a cui il gruppo si è ispirato per il nome.
 - `drawings/`: contiene tutti i diagrammi UML usati per descrivere il progetto.
 - `gradle/`: ospita il `.jar` relativo al sistema di gestione delle dipendenze *Gradle*.
 - `lib`: include eventuali librerie esterne utilizzate dal progetto.
 - `res`: contiene risorse varie utilizzate dal sistema
 - `src`: cartella principale del progetto, in cui scrivere tutto il codice dell’applicazione. In `main/` ci saranno i file sorgente e `test/` conterrà i test di unità previsti.
 - `.gitignore`: specifica tutti i file che devono essere esclusi dal sistema di controllo versione.
+- `Dockerfile`: file di configurazione per la creazione di un’immagine Docker.
 - `build.gradle`: esplicita le direttive e la configurazione di *Gradle*.
 - `gradlew` e `gradlew.bat`: eseguibili di *Gradle*, rispettivamente dedicati a Unix e Windows.
 - `settings.gradle`: file di configurazione di *Gradle*.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ La struttura della repository si presenta nel seguente modo:
 |–– src
 |    |–– main
 |    |–– test
+|–– .gitattributes
 |–– .gitignore
-|–– build.gradle
+|–– Dockerfile
 |–– README.md
+|–– build.gradle
 |–– gradlew
 |–– gradle.bat
 |–– settings.gradle
@@ -40,19 +42,19 @@ La struttura della repository si presenta nel seguente modo:
 
 Nel seguito si dettagliano i ruoli dei diversi componenti:
 
-- `.github/workflows/ingsw2122.yml`: dettaglia le direttive per assicurare la *continuous integration* attraverso l’uso di GitHub Actions;
+- `.github/workflows/`: contiene i file che dettagliano le direttive per assicurare la *continuous integration* attraverso l’uso di GitHub Actions;
 - `build/`: ospita la sottocartella `reports/`, contenente gli output dei tool automatici di test e controllo di qualità;
-- `config/`: ospita i file di configurazione. L’unica configurazione di base richiesta è quella per il tool checkstyle;
+- `config/`: ospita i file di configurazione. Le configurazioni di base richieste sono quelle per i tool checkstyle e PMD;
 - `docs/`: ospita la documentazione di progetto, incluse le figure (nella sottocartella `img/`).
   Il file `Report.md` verrà usato per redigere la relazione finale del progetto.
   La cartella raccoglie inoltre:
   - `Assegnazione progetto.md`: contenente la descrizione dettagliata del progetto assegnato;
   - `Guida per lo studente.md`: contenente la descrizione di tutti i passi di configurazione necessari per l'attivazione del flusso di lavoro a supporto dello sviluppo del progetto;
+- `drawings/`: contiene tutti i diagrammi UML usati per descrivere il progetto.
 - `gradle/`: ospita il `.jar` relativo al sistema di gestione delle dipendenze *Gradle*.
 - `lib`: include eventuali librerie esterne utilizzate dal progetto.
 - `res`: contiene risorse varie utilizzate dal sistema
 - `src`: cartella principale del progetto, in cui scrivere tutto il codice dell’applicazione. In `main/` ci saranno i file sorgente e `test/` conterrà i test di unità previsti.
-- `drawings/`: contiene tutti i diagrammi UML usati per descrivere il progetto.
 - `.gitignore`: specifica tutti i file che devono essere esclusi dal sistema di controllo versione.
 - `build.gradle`: esplicita le direttive e la configurazione di *Gradle*.
 - `gradlew` e `gradlew.bat`: eseguibili di *Gradle*, rispettivamente dedicati a Unix e Windows.


### PR DESCRIPTION
La struttura e le descrizioni di file e cartelle sono state aggiornate allo stato corrente del repository, eccetto per la cartella build, al momento non presente ma che ho deciso di mantenere nel README.md perché verrà creata in futuro.