### PR TITLE
correzione struttura della repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ La struttura della repository si presenta nel seguente modo:
 |–– README.md
 |–– build.gradle
 |–– gradlew
-|–– gradle.bat
+|–– gradlew.bat
 |–– settings.gradle
 ```
 


### PR DESCRIPTION
Modifica della struttura della repository contenuta nel file README.md: sostituito il nome del file "gradle.bat" con il nome corretto "gradlew.bat"